### PR TITLE
Update to 1.20.1 to support more entity types.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,10 @@
               <shadedPattern>wtf.choco.alchema.metrics</shadedPattern>
             </relocation>
             <relocation>
+              <pattern>org.apache.commons.lang</pattern>
+              <shadedPattern>wtf.choco.alchema.lang</shadedPattern>
+            </relocation>
+            <relocation>
               <pattern>wtf.choco.commons</pattern>
               <shadedPattern>wtf.choco.alchema.commons</shadedPattern>
             </relocation>
@@ -129,7 +133,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.18.2-R0.1-SNAPSHOT</version>
+      <version>1.20.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 
@@ -151,6 +155,13 @@
       <groupId>com.github.2008Choco</groupId>
       <artifactId>ChocoCommons</artifactId>
       <version>5fab5b2561</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/main/java/wtf/choco/alchema/essence/DefaultEntityEffects.java
+++ b/src/main/java/wtf/choco/alchema/essence/DefaultEntityEffects.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.ApiStatus.Internal;
 final class DefaultEntityEffects {
 
     // A
+    static final EssenceConsumptionCallback ALLAY = null;
     static final EssenceConsumptionCallback AXOLOTL = (player, essenceData, item, amountOfEssence, potency) -> {
         player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 80 + (int) (potency * 60), 0, true));
     };
@@ -54,6 +55,7 @@ final class DefaultEntityEffects {
     };
 
     // C
+    static final EssenceConsumptionCallback CAMEL = null;
     static final EssenceConsumptionCallback CAT = (player, essenceData, item, amountOfEssence, potency) -> {
         Random random = ThreadLocalRandom.current();
         Location location = player.getLocation();
@@ -174,7 +176,9 @@ final class DefaultEntityEffects {
 
     // F
     static final EssenceConsumptionCallback FOX = null;
-
+    static final EssenceConsumptionCallback FROG = (player, essenceData, item, amountOfEssence, potency) -> {
+        player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 40 + (int) (60 * potency), 0, true));
+    };
     // G
     static final EssenceConsumptionCallback GHAST = null;
     static final EssenceConsumptionCallback GIANT = null;
@@ -235,6 +239,7 @@ final class DefaultEntityEffects {
     static final EssenceConsumptionCallback SKELETON = null;
     static final EssenceConsumptionCallback SKELETON_HORSE = null;
     static final EssenceConsumptionCallback SLIME = null;
+    static final EssenceConsumptionCallback SNIFFER = null;
     static final EssenceConsumptionCallback SNOWMAN = null;
     static final EssenceConsumptionCallback SPIDER = null;
     static final EssenceConsumptionCallback SQUID = null;
@@ -242,6 +247,7 @@ final class DefaultEntityEffects {
     static final EssenceConsumptionCallback STRIDER = null;
 
     // T
+    static final EssenceConsumptionCallback TADPOLE = null;
     static final EssenceConsumptionCallback TRADER_LLAMA = null;
     static final EssenceConsumptionCallback TROPICAL_FISH = null;
     static final EssenceConsumptionCallback TURTLE = null;
@@ -253,6 +259,7 @@ final class DefaultEntityEffects {
 
     // W
     static final EssenceConsumptionCallback WANDERING_TRADER = null;
+    static final EssenceConsumptionCallback WARDEN = null;
     static final EssenceConsumptionCallback WITCH = null;
     static final EssenceConsumptionCallback WITHER = null;
     static final EssenceConsumptionCallback WITHER_SKELETON = null;

--- a/src/main/java/wtf/choco/alchema/essence/EntityEssenceEffectRegistry.java
+++ b/src/main/java/wtf/choco/alchema/essence/EntityEssenceEffectRegistry.java
@@ -116,6 +116,7 @@ public final class EntityEssenceEffectRegistry {
         Preconditions.checkArgument(registry != null, "registry must not be null");
 
         // A
+        register(registry, EntityType.ALLAY, 0x00DAFF, DefaultEntityEffects.ALLAY);
         register(registry, EntityType.AXOLOTL, 0xF59DE0, DefaultEntityEffects.AXOLOTL);
 
         // B
@@ -124,6 +125,7 @@ public final class EntityEssenceEffectRegistry {
         register(registry, EntityType.BLAZE, 0xB76D00, DefaultEntityEffects.BLAZE);
 
         // C
+        register(registry, EntityType.CAMEL, 0xCB9337, DefaultEntityEffects.CAMEL);
         register(registry, EntityType.CAT, 0x937155, DefaultEntityEffects.CAT);
         register(registry, EntityType.CAVE_SPIDER, 0x002D31, DefaultEntityEffects.CAVE_SPIDER);
         register(registry, EntityType.CHICKEN, 0xB90000, DefaultEntityEffects.CHICKEN);
@@ -145,6 +147,7 @@ public final class EntityEssenceEffectRegistry {
 
         // F
         register(registry, EntityType.FOX, 0xE48D40, DefaultEntityEffects.FOX);
+        register(registry, EntityType.FROG, 0xD07444, DefaultEntityEffects.FROG);
 
         // G
         register(registry, EntityType.GHAST, 0xAFAFAF, DefaultEntityEffects.GHAST);
@@ -197,6 +200,7 @@ public final class EntityEssenceEffectRegistry {
         register(registry, EntityType.SKELETON, 0xFFFFFF, DefaultEntityEffects.SKELETON);
         register(registry, EntityType.SKELETON_HORSE, 0x707070, DefaultEntityEffects.SKELETON_HORSE);
         register(registry, EntityType.SLIME, 0x75BF65, DefaultEntityEffects.SLIME);
+        register(registry, EntityType.SNIFFER, 0x962930, DefaultEntityEffects.SNIFFER);
         register(registry, EntityType.SNOWMAN, 0xADC8C8, DefaultEntityEffects.SNOWMAN);
         register(registry, EntityType.SPIDER, 0x241F1C, DefaultEntityEffects.SPIDER);
         register(registry, EntityType.SQUID, 0x3D4f5D, DefaultEntityEffects.SQUID);
@@ -204,6 +208,7 @@ public final class EntityEssenceEffectRegistry {
         register(registry, EntityType.STRIDER, 0x913032, DefaultEntityEffects.STRIDER);
 
         // T
+        register(registry, EntityType.TADPOLE, 0x6D533D, DefaultEntityEffects.TADPOLE);
         register(registry, EntityType.TRADER_LLAMA, 0x38507A, DefaultEntityEffects.TRADER_LLAMA);
         register(registry, EntityType.TROPICAL_FISH, 0xD85F13, DefaultEntityEffects.TROPICAL_FISH);
         register(registry, EntityType.TURTLE, 0x46BD49, DefaultEntityEffects.TURTLE);
@@ -215,6 +220,7 @@ public final class EntityEssenceEffectRegistry {
 
         // W
         register(registry, EntityType.WANDERING_TRADER, 0x435F91, DefaultEntityEffects.WANDERING_TRADER);
+        register(registry, EntityType.WARDEN, 0x0F4649, DefaultEntityEffects.WARDEN);
         register(registry, EntityType.WITCH, 0x351757, DefaultEntityEffects.WITCH);
         register(registry, EntityType.WITHER, 0x262626, DefaultEntityEffects.WITHER);
         register(registry, EntityType.WITHER_SKELETON, 0x1E1E1E, DefaultEntityEffects.WITHER_SKELETON);


### PR DESCRIPTION
This caused it to give an error on commons-lang missing, so added as a dependency and shaded it.